### PR TITLE
Added status code based error checking on HTTP responses

### DIFF
--- a/pyeactivities/exceptions.py
+++ b/pyeactivities/exceptions.py
@@ -1,0 +1,10 @@
+class APIException(Exception):
+    pass
+
+
+class APIUnauthorisedException(APIException):
+    pass
+
+
+class APIForbiddenException(APIException):
+    pass

--- a/pyeactivities/http.py
+++ b/pyeactivities/http.py
@@ -1,5 +1,11 @@
 import requests
 
+from pyeactivities.exceptions import (
+    APIException,
+    APIUnauthorisedException,
+    APIForbiddenException,
+)
+
 DEFAULT_USER_AGENT = "pyeactivities/0.1.0"
 
 
@@ -11,9 +17,22 @@ class EActivitesClient:
 
     def _get(self, endpoint):
         url = self.endpoint_base + endpoint
-        return requests.get(
+        r = requests.get(
             url, headers={"X-API-Key": self.api_key, "User-Agent": self.user_agent}
         )
+
+        if r.status_code == 200:
+            return r
+        elif r.status_code == 401:
+            raise APIUnauthorisedException(
+                "API returned status code 401 - are you using a correct API key?"
+            )
+        elif r.status_code == 403:
+            raise APIForbiddenException(
+                "API returned status code 403 - too many requests and/or too many repeated failed attempts"
+            )
+        else:
+            raise APIException("API returned status code {}".format(r.status_code))
 
     def get(self, endpoint):
         r = self._get(endpoint)


### PR DESCRIPTION
Fixes #1, this PR adds checks to the `_get` method of the HTTP client to check the response's status code for 401 response (e.g. incorrect API key) and 403 response (rate limited).