### PR TITLE
Save pytest test results to CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ jobs:
             - "/usr/local/lib/python3.7/site-packages"
       - run:
           command: |
-            pipenv run python -m pytest tests --junitxml=test-results/report.xml
+            pipenv run python -m pytest tests --junitxml=test-results/pytest/pytest-report.xml
       - store_test_results:
           path: test-results
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,9 +26,8 @@ jobs:
             - "/usr/local/lib/python3.7/site-packages"
       - run:
           command: |
-            pipenv run python -m pytest tests
+            pipenv run python -m pytest tests --junitxml=test-results/report.xml
       - store_test_results:
           path: test-results
       - store_artifacts:
           path: test-results
-          destination: tr1


### PR DESCRIPTION
This modifies the CircleCI config to export the pytest test results to an XML file that CircleCI can then pick up and display.