### PR TITLE
Changed deploy jobs in CI config to ignore all branches

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,12 +1,17 @@
 version: 2
 workflows:
   version: 2
-  main:
+  build:
+    jobs:
+      - test
+  build-and-deploy:
     jobs:
       - test:
           filters:
             tags:
-              only: /.*/
+              only: /\d+\.\d+\.\d+(?:-.*)?/
+            branches:
+              ignore: /.*/
       - build-dist:
           requires:
             - test
@@ -14,7 +19,7 @@ workflows:
             tags:
               only: /\d+\.\d+\.\d+(?:-.*)?/
             branches:
-              only: master
+              ignore: /.*/
       - release-github:
           requires:
             - build-dist
@@ -22,7 +27,7 @@ workflows:
             tags:
               only: /\d+\.\d+\.\d+(?:-.*)?/
             branches:
-              only: master
+              ignore: /.*/
 
 jobs:
   test:


### PR DESCRIPTION
Closes #10, this splits the CI workflow into two workflows, one for just building and one for building and deploying. Every job in the build and deploy workflow is set up to only run on version tags and to ignore branches.