### PR TITLE
Modified branch/tag filter for CI test stage

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,17 +1,13 @@
 version: 2
 workflows:
   version: 2
-  build:
-    jobs:
-      - test
+
   build-and-deploy:
     jobs:
       - test:
           filters:
             tags:
-              only: /\d+\.\d+\.\d+(?:-.*)?/
-            branches:
-              ignore: /.*/
+              only: /.*/ # required since further stages have tag filters and require 'test'
       - build-dist:
           requires:
             - test


### PR DESCRIPTION
Removed `build` workflow and set filters on `build-and-deploy` `test` stage to run on every tag.